### PR TITLE
Only reinit random number generator if seed nonzero

### DIFF
--- a/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
+++ b/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
@@ -215,7 +215,9 @@ namespace tk
                     path_mgr.turnInc = turn_increment;
                 }
 
-                UnityEngine.Random.InitState(rand_seed);
+                if (rand_seed != 0) {
+                    UnityEngine.Random.InitState(rand_seed);
+                }
                 train_mgr.SetRoadStyle(road_style);
                 train_mgr.OnMenuRegenTrack();
             }

--- a/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
+++ b/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
@@ -73,6 +73,7 @@ namespace tk
             client.dispatcher.Register("step_mode", new tk.Delegates.OnMsgRecv(OnStepModeRecv));
             client.dispatcher.Register("quit_app", new tk.Delegates.OnMsgRecv(OnQuitApp));
             client.dispatcher.Register("regen_road", new tk.Delegates.OnMsgRecv(OnRegenRoad));
+            client.dispatcher.Register("next_track", new tk.Delegates.OnMsgRecv(OnNextTrack));
 
         }
 
@@ -220,6 +221,25 @@ namespace tk
                 }
                 train_mgr.SetRoadStyle(road_style);
                 train_mgr.OnMenuRegenTrack();
+            }
+
+            yield return null;
+        }
+
+        
+        void OnNextTrack(JSONObject json)
+        {
+            // Cycle through next track
+            UnityMainThreadDispatcher.Instance().Enqueue(NextTrack());
+        }
+
+        IEnumerator NextTrack()
+        {
+            TrainingManager train_mgr = GameObject.FindObjectOfType<TrainingManager>();
+
+            if(train_mgr != null)
+            {
+                train_mgr.OnMenuNextTrack();
             }
 
             yield return null;


### PR DESCRIPTION
Fixes an issue I ran into in https://github.com/tawnkramer/sdsandbox/issues/24

If the random number generator is reset with the same seed repeatedly, it will keep doing the same thing.  It probably doesn't make sense to reset the random number generator unless it's non-zero, so this just wraps it in an if statement check.