### PR TITLE
Improve car respawning for RL learning

### DIFF
--- a/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
+++ b/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
@@ -396,6 +396,11 @@ namespace tk
                     {
                         LapTimer t = carObj.transform.GetComponentInChildren<LapTimer>();
 
+                        //reset last controls
+                        car.RequestSteering(0.0f);
+                        car.RequestThrottle(0.0f);
+                        car.RequestFootBrake(10.0f);
+
                         if(t != null)
                         {
                             t.ResetRace();


### PR DESCRIPTION
Thx tons for a so inspiring framework! Love playing with donkeycar!!!

Now to explaing my idea:
I am experimenting with antonin's RL client for the donkeycar envirmonment. 
I observed a delayed control of the RL client leading to a start of the donkey with old parameters. (This lead to often 1step RL loops where the abort condition was reached almost before algo could even take over for a few steps.) 
I could address this successful with also reseting last action parameters (steer, throttle) in the Unity reset handling process.
Would appreciate this one being part of the main sdsandbox release. 
If other work around exist I am happily willing to learn ;o)

(I am playing here:
https://github.com/Jekyll555/learning-to-drive-in-5-minutes/tree/noobs/getItRun_understandIt 
)