### PR TITLE
changed gyro values to be a vect3 angular velocity instead of quaternion

### DIFF
--- a/sdsim/Assets/Scripts/Car.cs
+++ b/sdsim/Assets/Scripts/Car.cs
@@ -157,7 +157,7 @@ public class Car : MonoBehaviour, ICar{
 	{
 		return acceleration;
 	}
-	public Quaternion GetGyro()
+	public Vector3 GetGyro()
 	{
 	  return gyro;
   	}
@@ -210,7 +210,7 @@ public class Car : MonoBehaviour, ICar{
 		prevVel = velocity;
 		velocity = transform.InverseTransformDirection(rb.velocity);
 		acceleration = (velocity - prevVel)/Time.deltaTime;
-		gyro = rb.rotation * Quaternion.Inverse(rotation);
+		gyro = angularVelocity; // rb.rotation * Quaternion.Inverse(rotation);
 		rotation = rb.rotation;
 
 		// use the torque curve

--- a/sdsim/Assets/Scripts/Car.cs
+++ b/sdsim/Assets/Scripts/Car.cs
@@ -26,7 +26,7 @@ public class Car : MonoBehaviour, ICar{
 	public Vector3 startPos;
 	public Quaternion startRot;
 	private Quaternion rotation = Quaternion.identity;
-	private Quaternion gyro = Quaternion.identity;
+	private Vector3 gyro = Vector3.zero;
 
 	public Rigidbody rb;
 
@@ -210,7 +210,7 @@ public class Car : MonoBehaviour, ICar{
 		prevVel = velocity;
 		velocity = transform.InverseTransformDirection(rb.velocity);
 		acceleration = (velocity - prevVel)/Time.deltaTime;
-		gyro = angularVelocity; // rb.rotation * Quaternion.Inverse(rotation);
+		gyro = rb.angularVelocity;
 		rotation = rb.rotation;
 
 		// use the torque curve

--- a/sdsim/Assets/Scripts/ICar.cs
+++ b/sdsim/Assets/Scripts/ICar.cs
@@ -38,7 +38,7 @@ public interface ICar
 
 	Vector3 GetAccel();
 
-	Quaternion GetGyro();
+	Vector3 GetGyro();
 
 	//mark the current activity for partial selections when creating training sets later.
 	string GetActivity();

--- a/sdsim/Assets/Scripts/UnityStandardCarAdapter.cs
+++ b/sdsim/Assets/Scripts/UnityStandardCarAdapter.cs
@@ -111,7 +111,7 @@ public class UnityStandardCarAdapter : MonoBehaviour, ICar {
 		vel = rb.velocity;
 
 		unityCar.Move(steering / MaximumSteerAngle, throttle, footBrake, handBrake);
-		gyro = -rb.angularVelocity;
+		gyro = rb.angularVelocity;
 		rotation = rb.rotation;
 	}
 

--- a/sdsim/Assets/Scripts/UnityStandardCarAdapter.cs
+++ b/sdsim/Assets/Scripts/UnityStandardCarAdapter.cs
@@ -14,7 +14,7 @@ public class UnityStandardCarAdapter : MonoBehaviour, ICar {
 	Vector3 vel = Vector3.zero;
 	Vector3 accel = Vector3.zero;
 	Quaternion rotation = Quaternion.identity;
-	Quaternion gyro = Quaternion.identity;
+	Vector3 gyro = Vector3.zero;
 	public string activity = "keep_lane";
 
 	Rigidbody rb;
@@ -57,7 +57,7 @@ public class UnityStandardCarAdapter : MonoBehaviour, ICar {
 	}
 
 	public Vector3 GetAccel() { return accel; }
-	public Quaternion GetGyro() { return gyro; }
+	public Vector3 GetGyro() { return gyro; }
     public void SetMaxSteering(float val)
     {
         MaximumSteerAngle = val;
@@ -111,7 +111,7 @@ public class UnityStandardCarAdapter : MonoBehaviour, ICar {
 		vel = rb.velocity;
 
 		unityCar.Move(steering / MaximumSteerAngle, throttle, footBrake, handBrake);
-		gyro = rb.rotation * Quaternion.Inverse(rotation);
+		gyro = -rb.angularVelocity;
 		rotation = rb.rotation;
 	}
 

--- a/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
+++ b/sdsim/Assets/Scripts/tcp/TcpCarHandler.cs
@@ -181,12 +181,10 @@ namespace tk
             json.AddField("accel_y", accel.y);
             json.AddField("accel_z", accel.z);
 
-            Quaternion gyro = car.GetGyro();
+            Vector3 gyro = car.GetGyro();
             json.AddField("gyro_x", gyro.x);
             json.AddField("gyro_y", gyro.y);
             json.AddField("gyro_z", gyro.z);
-            json.AddField("gyro_w", gyro.w);
-
 
             Transform tm = car.GetTransform();
             Vector3 eulerAngles = tm.rotation.eulerAngles;


### PR DESCRIPTION
Just a small PR to change the old gyro quaternion values to something more readable,
Now using the RigidBody.angularVelocity which return a Vector3